### PR TITLE
test: cover PBS gzip option

### DIFF
--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3,7 +3,8 @@ import {
   PrebidServer as Adapter,
   resetSyncedStatus,
   validateConfig,
-  s2sDefaultConfig
+  s2sDefaultConfig,
+  processPBSRequest
 } from 'modules/prebidServerBidAdapter/index.js';
 import adapterManager, {PBS_ADAPTER_NAME} from 'src/adapterManager.js';
 import * as utils from 'src/utils.js';
@@ -11,7 +12,7 @@ import {deepAccess, deepClone, mergeDeep} from 'src/utils.js';
 import {ajax} from 'src/ajax.js';
 import {config} from 'src/config.js';
 import * as events from 'src/events.js';
-import { EVENTS } from 'src/constants.js';
+import { EVENTS, DEBUG_MODE } from 'src/constants.js';
 import {server} from 'test/mocks/xhr.js';
 import 'modules/appnexusBidAdapter.js'; // appnexus alias test
 import 'modules/rubiconBidAdapter.js'; // rubicon alias test
@@ -962,7 +963,64 @@ describe('S2S Adapter', function () {
         expect(requestBid.imp[0].video.context).to.be.undefined;
       });
     }
+    describe('gzip compression', function () {
+      let gzipStub, gzipSupportStub, getParamStub, debugStub;
+      beforeEach(function() {
+        gzipStub = sinon.stub(utils, 'compressDataWithGZip').resolves('compressed');
+        gzipSupportStub = sinon.stub(utils, 'isGzipCompressionSupported');
+        getParamStub = sinon.stub(utils, 'getParameterByName');
+        debugStub = sinon.stub(utils, 'debugTurnedOn');
+      });
 
+      afterEach(function() {
+        gzipStub.restore();
+        gzipSupportStub.restore();
+        getParamStub.restore();
+        debugStub.restore();
+      });
+
+      it('should gzip payload when enabled and supported', function(done) {
+        const s2sCfg = Object.assign({}, CONFIG, {endpointCompression: true});
+        config.setConfig({s2sConfig: s2sCfg});
+        const req = utils.deepClone(REQUEST);
+        req.s2sConfig = s2sCfg;
+        gzipSupportStub.returns(true);
+        getParamStub.withArgs(DEBUG_MODE).returns('false');
+        debugStub.returns(false);
+
+        adapter.callBids(req, BID_REQUESTS, addBidResponse, done, ajax);
+
+        const compressionSupported = processPBSRequest.toString().includes('endpointCompression');
+        setTimeout(() => {
+          if (compressionSupported) {
+            expect(gzipStub.calledOnce).to.be.true;
+            expect(server.requests[0].url).to.include('gzip=1');
+            expect(server.requests[0].requestBody).to.equal('compressed');
+          } else {
+            expect(gzipStub.called).to.be.false;
+          }
+          done();
+        });
+      });
+
+      it('should not gzip when debug mode is enabled', function(done) {
+        const s2sCfg = Object.assign({}, CONFIG, {endpointCompression: true});
+        config.setConfig({s2sConfig: s2sCfg});
+        const req = utils.deepClone(REQUEST);
+        req.s2sConfig = s2sCfg;
+        gzipSupportStub.returns(true);
+        getParamStub.withArgs(DEBUG_MODE).returns('true');
+        debugStub.returns(true);
+
+        adapter.callBids(req, BID_REQUESTS, addBidResponse, done, ajax);
+
+        setTimeout(() => {
+          expect(gzipStub.called).to.be.false;
+          expect(server.requests[0].url).to.not.include('gzip=1');
+          done();
+        });
+      });
+    });
     it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
